### PR TITLE
BUILD-800 Exit with error code 1 if no release info is available

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ def main():
 
     if not release_info:
         print(f"::error  No release info found")
-        return
+        sys.exit(1)
 
     r=check_releasability(repo, version, headers)
     if releasability_passed(r):


### PR DESCRIPTION
This step was not marked as failed if no release information was available.